### PR TITLE
Fix user session invalidation on account deactivation

### DIFF
--- a/BusinessLogic/Servicios/Usuarios/UsuarioService.cs
+++ b/BusinessLogic/Servicios/Usuarios/UsuarioService.cs
@@ -6,9 +6,7 @@ using DataAccess.Modelos.DTOs.Wrappers;
 using DataAccess.Modelos.Entidades;
 using DataAccess.Repositorios.Auditorias;
 using DataAccess.Repositorios.Usuarios;
-using DocumentFormat.OpenXml.Spreadsheet;
 using Microsoft.AspNetCore.Identity;
-using Microsoft.IdentityModel.Tokens;
 
 
 namespace BusinessLogic.Servicios.Usuarios
@@ -343,6 +341,7 @@ namespace BusinessLogic.Servicios.Usuarios
             }
 
             var usuario = await _usuarioRepository.ObtenerUsuarioPorIdAsync(id);
+
             if (usuario == null)
             {
                 throw new InvalidOperationException("Usuario no encontrado.");
@@ -350,16 +349,33 @@ namespace BusinessLogic.Servicios.Usuarios
 
             await _usuarioRepository.DesactivarUsuario(id);
 
-            var user = await _userManager.FindByIdAsync(usuario.Id);
+            var user = await _userManager.FindByIdAsync(id);
 
-            //Auditoria
+            if (user == null)
+            {
+                throw new InvalidOperationException("Usuario no encontrado.");
+            }
+
+            // Invalidar todas las sesiones/cookies existentes del usuario.
+            var stampResult = await _userManager.UpdateSecurityStampAsync(user);
+
+            if (!stampResult.Succeeded)
+            {
+                throw new InvalidOperationException(
+                    "El usuario fue desactivado, pero no se pudieron invalidar sus sesiones activas."
+                );
+            }
+
+            // Auditoria
             var auditoria = new Auditoria
             {
                 Fecha = _helper.ObtenerFechaHoyCR(),
                 Hora = _helper.ObtenerHoraCR(),
                 Usuario = user.nombreCompleto,
                 Tabla = "Usuario",
-                Accion = "Cambio de Estado de " + usuario.PrimerNombre + " " + usuario.PrimerApellido
+                Accion = "Cambio de Estado de " +
+                         usuario.PrimerNombre + " " +
+                         usuario.PrimerApellido
             };
 
             await _audit.AgregarAuditoria(auditoria);

--- a/SASA/Program.cs
+++ b/SASA/Program.cs
@@ -136,7 +136,9 @@ builder.Services.ConfigureApplicationCookie(options =>
 // Security Stamp
 builder.Services.Configure<SecurityStampValidatorOptions>(options =>
 {
-    options.ValidationInterval = TimeSpan.FromMinutes(5);
+    // Validar el SecurityStamp en cada solicitud autenticada.
+    // Así una desactivación invalida SASA.Auth desde la siguiente petición.
+    options.ValidationInterval = TimeSpan.Zero;
 });
 
 // Repositories y servicios de negocio

--- a/SASA/wwwroot/js/site.js
+++ b/SASA/wwwroot/js/site.js
@@ -1,9 +1,19 @@
 ﻿//Contador de notificacione
 async function actualizarIndicadorNotificaciones() {
     try {
-        const res = await fetch('/Notificaciones/Contador', { credentials: 'same-origin' });
+        const res = await fetch('/Notificaciones/Contador', {
+            credentials: 'same-origin'
+        });
 
-        if (res.redirected) return;
+        if (res.redirected) {
+            window.location.href = res.url || '/login';
+            return;
+        }
+
+        if (res.status === 401 || res.status === 403) {
+            window.location.href = '/login';
+            return;
+        }
 
         const total = await res.json();
         const badge = document.getElementById('notifBadge');


### PR DESCRIPTION
## Description

This PR fixes an issue where a user could remain logged into SASA even after an administrator deactivated their account.

### Changes implemented

* Updated user deactivation logic to invalidate the user's existing authentication sessions using ASP.NET Identity `SecurityStamp`.
* Configured `SecurityStamp` validation to occur on authenticated requests, allowing deactivated accounts to be detected immediately.
* Updated the existing notification polling logic to redirect users to the login page when their authentication session becomes invalid.
* Ensured that all active sessions for the same user are invalidated, including sessions opened in different browsers.
* Maintained the existing restriction that prevents deactivated users from logging in again until their account is reactivated.

### Expected behavior

When an administrator deactivates a user:

1. The user's active authentication sessions are invalidated.
2. Any subsequent request made from an active session is rejected.
3. If the user remains inactive on a page, the existing notification polling detects the invalid session and redirects them to login.
4. The user cannot log in again while the account remains deactivated.
5. Once reactivated, the user must authenticate again to obtain a new valid session.

### Testing

* Verified account deactivation while the user had an active session.
* Verified automatic redirection to login after session invalidation.
* Verified that a deactivated account cannot authenticate again.
* Verified invalidation when the same account is active in multiple browsers.
